### PR TITLE
Fixes for working with Versions

### DIFF
--- a/BuildTasks/Common/Common.ts
+++ b/BuildTasks/Common/Common.ts
@@ -82,11 +82,19 @@ export function setTfxManifestArguments(tfx: ToolRunner): (() => void) {
         if (isPreview) { jsonOverrides.galleryFlags = ["Preview"]; };
     }
 
-    const extensionVersion = tl.getInput("extensionVersion", false);
+    let extensionVersion = tl.getInput("extensionVersion", false);
     if (extensionVersion) {
-        tl.debug(`Overriding extension version to: ${extensionVersion}`);
-        jsonOverrides = (jsonOverrides || {});
-        jsonOverrides.version = extensionVersion;
+       const extractedVersions = extensionVersion.match(/[0-9]+\.[0-9]+\.[0-9]+/);
+       if (extractedVersions && extractedVersions.length === 1) {
+            extensionVersion = extractedVersions[0];
+            tl.debug(`Overriding extension version to: ${extensionVersion}`);
+            jsonOverrides = (jsonOverrides || {});
+            jsonOverrides.version = extensionVersion;
+        }
+        else
+        {
+            tl.error(`Supplied ExtensionVersion must contain a string matching '##.##.##'.`);
+        }
     }
 
     let overrideFilePath: string;

--- a/BuildTasks/Common/Common.ts
+++ b/BuildTasks/Common/Common.ts
@@ -158,7 +158,7 @@ export function runTfx(cmd: (tfx: ToolRunner) => void) {
 export function getExtensionVersion(): string {
     const extensionVersion = tl.getInput("extensionVersion", false);
     if (extensionVersion) {
-        const extractedVersions = extensionVersion.match(/[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?/);
+        const extractedVersions = extensionVersion.match(/[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?/);
         if (extractedVersions && extractedVersions.length === 1) {
             return extractedVersions[0];
         }

--- a/BuildTasks/Common/Common.ts
+++ b/BuildTasks/Common/Common.ts
@@ -191,7 +191,7 @@ export class TfxJsonOutputStream extends stream.Writable {
             this.commandline = chunkStr;
             if (!this.silent) { this.taskOutput(chunkStr, tl._writeLine); }
         }
-        else if (!this.jsonString && chunkStr.toString()[0] !== "{") {
+        else if (!this.jsonString && (chunkStr.toString()[0] !== "{" || chunkStr.toString()[0] !== "[")) {
             this.messages.push(chunkStr);
             if (!this.silent) { this.taskOutput(chunkStr, tl.warning); }
         }

--- a/BuildTasks/Common/Common.ts
+++ b/BuildTasks/Common/Common.ts
@@ -211,7 +211,7 @@ export class TfxJsonOutputStream extends stream.Writable {
             this.commandline = chunkStr;
             if (!this.silent) { this.taskOutput(chunkStr, tl._writeLine); }
         }
-        else if (!this.jsonString && (chunkStr.toString()[0] !== "{" || chunkStr.toString()[0] !== "[")) {
+        else if (!this.jsonString && (chunkStr.toString()[0] !== "{" && chunkStr.toString()[0] !== "[")) {
             this.messages.push(chunkStr);
             if (!this.silent) { this.taskOutput(chunkStr, tl.warning); }
         }

--- a/BuildTasks/Common/Common.ts
+++ b/BuildTasks/Common/Common.ts
@@ -163,7 +163,7 @@ export function getExtensionVersion(): string {
             return extractedVersions[0];
         }
         else {
-            tl.error(`Supplied ExtensionVersion must contain a string matching '##.##.##'.`);
+            throw new Error(`Supplied ExtensionVersion must contain a string matching '##.##.##(.##)'.`);
         }
     }
     return null;

--- a/BuildTasks/PublishExtension/PublishExtension.ts
+++ b/BuildTasks/PublishExtension/PublishExtension.ts
@@ -43,20 +43,9 @@ common.runTfx(tfx => {
 
         const extensionName = tl.getInput("extensionName", false);
         const extensionVisibility = tl.getInput("extensionVisibility", false);
-                
-        let extensionVersion = tl.getInput("extensionVersion", false);
-        if (extensionVersion) {
-            const extractedVersions = extensionVersion.match(/[0-9]+\.[0-9]+\.[0-9]+/);
-            if (extractedVersions && extractedVersions.length === 1) {
-                extensionVersion = extractedVersions[0];
-                tl.debug(`Overriding extension version to: ${extensionVersion}`);
-            }
-            else
-            {
-                tl.error(`Supplied Extension Version must contain a string matching '##.##.##'.`);
-            }
-        }
-        
+
+        let extensionVersion = common.getExtensionVersion();
+
         const updateTasksVersion = tl.getBoolInput("updateTasksVersion", false);
 
         if (publisher

--- a/BuildTasks/PublishExtension/PublishExtension.ts
+++ b/BuildTasks/PublishExtension/PublishExtension.ts
@@ -43,7 +43,20 @@ common.runTfx(tfx => {
 
         const extensionName = tl.getInput("extensionName", false);
         const extensionVisibility = tl.getInput("extensionVisibility", false);
-        const extensionVersion = tl.getInput("extensionVersion", false);
+                
+        let extensionVersion = tl.getInput("extensionVersion", false);
+        if (extensionVersion) {
+            const extractedVersions = extensionVersion.match(/[0-9]+\.[0-9]+\.[0-9]+/);
+            if (extractedVersions && extractedVersions.length === 1) {
+                extensionVersion = extractedVersions[0];
+                tl.debug(`Overriding extension version to: ${extensionVersion}`);
+            }
+            else
+            {
+                tl.error(`Supplied Extension Version must contain a string matching '##.##.##'.`);
+            }
+        }
+        
         const updateTasksVersion = tl.getBoolInput("updateTasksVersion", false);
 
         if (publisher


### PR DESCRIPTION
Fixes:
 * Parser error from Query Version task (which returns a json object instead of a json array)
 * Extracts version number from the string passed to the version number textbox and removes any semver information or prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/vsts-extension-build-release-tasks/3)
<!-- Reviewable:end -->
