### PR TITLE
Change service connection name from VSTS Marketplace to VS Marketplace

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -145,7 +145,7 @@
       ],
       "properties": {
         "name": "VstsMarketplacePublishing",
-        "displayName": "VSTS Marketplace",
+        "displayName": "VS Marketplace",
         "url": {
           "displayName": "Marketplace URL",
           "value": "https://marketplace.visualstudio.com"
@@ -175,7 +175,7 @@
               {
                 "id": "password",
                 "name": "Personal access token",
-                "description": "Team Services personal access token. Requires at least the Marketplace (publish) scope.",
+                "description": "Azure DevOps personal access token. Requires at least the Marketplace (publish) scope.",
                 "inputMode": "passwordbox",
                 "isConfidential": true,
                 "validation": {


### PR DESCRIPTION
A small PR to change service connection name from VSTS marketplace to VS Marketplace. Also fixed a tooltip which had reference to Team Services.

![image](https://user-images.githubusercontent.com/2685029/48853626-ce398e80-eda7-11e8-8dac-2420521405b9.png)
