### PR TITLE
Add support for build tasks to update localized task.json versions

### DIFF
--- a/BuildTasks/Common/Common.ts
+++ b/BuildTasks/Common/Common.ts
@@ -486,20 +486,27 @@ function getTaskManifestPaths(manifestPath: string, manifest: object): string[] 
         tl.debug(`Found task: ${task}`);
         const taskRoot: string = path.join(rootFolder, task);
         const rootManifest: string = path.join(taskRoot, "task.json");
+
+        let localizationRoot = tl.getInput("localizationRoot", false);
+        if (localizationRoot) {
+            localizationRoot = path.resolve(localizationRoot);
+        }
+
         if (tl.exist(rootManifest)) {
             tl.debug(`Found single-task manifest: ${rootManifest}`);
             let rootManifests: string[] = [rootManifest];
-            const rootLocManifest: string = path.join(taskRoot, "task.loc.json");
+            const rootLocManifest: string = path.join(localizationRoot || taskRoot, "task.loc.json");
             if (tl.exist(rootLocManifest)) {
                 tl.debug(`Found localized single-task manifest: ${rootLocManifest}`);
                 rootManifests.push(rootLocManifest);
             }
             return (result).concat(rootManifests);
         } else {
-            const taskJsonPatterns: string[] = ["*/task.json", "*/task.loc.json"];
-            const versionManifests = tl.findMatch(taskRoot, taskJsonPatterns);
+            const versionManifests = tl.findMatch(taskRoot, "*/task.json");
+            const locVersionManifests = tl.findMatch(localizationRoot || taskRoot, "*/task.loc.json");
             tl.debug(`Found multi-task manifests: ${versionManifests.join(", ")}`);
-            return (result).concat(versionManifests);
+            tl.debug(`Found multi-task localized manifests: ${locVersionManifests.join(", ")}`);
+            return (result).concat(versionManifests).concat(locVersionManifests);
         }
     }, []);
 }

--- a/BuildTasks/Common/Common.ts
+++ b/BuildTasks/Common/Common.ts
@@ -488,9 +488,16 @@ function getTaskManifestPaths(manifestPath: string, manifest: object): string[] 
         const rootManifest: string = path.join(taskRoot, "task.json");
         if (tl.exist(rootManifest)) {
             tl.debug(`Found single-task manifest: ${rootManifest}`);
-            return (result).concat([rootManifest]);
+            let rootManifests: string[] = [rootManifest];
+            const rootLocManifest: string = path.join(taskRoot, "task.loc.json");
+            if (tl.exist(rootLocManifest)) {
+                tl.debug(`Found localized single-task manifest: ${rootLocManifest}`);
+                rootManifests.push(rootLocManifest);
+            }
+            return (result).concat(rootManifests);
         } else {
-            const versionManifests = tl.findMatch(taskRoot, "*/task.json");
+            const taskJsonPatterns: string[] = ["*/task.json", "*/task.loc.json"];
+            const versionManifests = tl.findMatch(taskRoot, taskJsonPatterns);
             tl.debug(`Found multi-task manifests: ${versionManifests.join(", ")}`);
             return (result).concat(versionManifests);
         }

--- a/scripts/setTaskVersion.js
+++ b/scripts/setTaskVersion.js
@@ -24,14 +24,20 @@ console.log("Setting all task versions to: " + JSON.stringify(newVersion));
 var buildTasksDir = path.join(__dirname, "../BuildTasks");
 var buildTaskNames = getBuildTasks();
 buildTaskNames.forEach(function(name) {
-    var taskJsonFile = path.join(buildTasksDir, name, "task.json");
-    console.log("Updating: " + taskJsonFile);
-    if (fs.existsSync(taskJsonFile)) {
-        var task = jsonfile.readFileSync(taskJsonFile);
+    var taskJsonFiles = [
+        path.join(buildTasksDir, name, "task.json"),
+        path.join(buildTasksDir, name, "task.loc.json")
+    ];
 
-        task["version"] = newVersion;
-
-        jsonfile.writeFileSync(taskJsonFile, task, {spaces: 2, EOL: '\r\n'});
-    }
+    taskJsonFiles.forEach(function(taskJsonFile) {
+        console.log("Updating: " + taskJsonFile);
+        if (fs.existsSync(taskJsonFile)) {
+            var task = jsonfile.readFileSync(taskJsonFile);
+    
+            task["version"] = newVersion;
+    
+            jsonfile.writeFileSync(taskJsonFile, task, {spaces: 2, EOL: '\r\n'});
+        }
+    });
 });
 


### PR DESCRIPTION
Currently, this build task can update a `task.json` version number, however, when tasks are localized, there is a `task.loc.json` file should have it's version updated in tandem. This adds support for updating this localized task manifest.